### PR TITLE
chore: add cli config from process.env

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -1,0 +1,8 @@
+import {defineCliConfig} from 'sanity/cli';
+
+export default defineCliConfig({
+  api: {
+    projectId: process.env.PUBLIC_SANITY_PROJECT_ID,
+    dataset: process.env.PUBLIC_SANITY_DATASET,
+  },
+});


### PR DESCRIPTION
`sanity.config.ts` uses import.meta, but I assume that runs in a different context. This setup seems to work at least in my local dev as long as I have a `.env.development` file with these variable names set.