### PR TITLE
chore: updated instructions to shopify headless app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,5 @@ PUBLIC_PREVIEW_URL='http://localhost:3000'
 PUBLIC_SHOPIFY_STORE_DOMAIN=my-store-name.myshopify.com
 
 # Your Shopify storefront API token
-# Used in Hydrogen config. For more info on how to create a Storefront API token: https://shopify.dev/api/usage/authentication#access-tokens-for-the-storefront-api
+# Used in Hydrogen config. To create a token, install the Shopify Headless app: https://apps.shopify.com/headless
 PUBLIC_STOREFRONT_API_TOKEN=

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ We've taken the following opinions on how we've approached this demo.
 
 These installation instructions assume you have already installed and configured [Sanity Connect][sanity-connect] on your Shopify store.
 
-1.  Duplicate the `.env.example` file to `.env` and replace the values to point to your Sanity project's `dataset` and `projectId`, and your Shopify storefront's `storeDomain` and `storefrontToken`. See [Shopify's documentation][storefront-api] on how to create a token for the Storefront API.
+1.  Duplicate the `.env.example` file to `.env` and replace the values to point to your Sanity project's `dataset` and `projectId`, and your Shopify storefront's `storeDomain` and `storefrontToken`. Use [Shopify's Headless app][shopify-headless-app] to manage tokens for the Storefront API.
 
 2.  Install dependencies and start the development server
 
@@ -177,7 +177,7 @@ This repository is published under the [MIT][license] license.
 [hydrogen-framework-deployment]: https://shopify.dev/custom-storefronts/hydrogen/deployment
 [hydrogen-product-components]: https://shopify.dev/api/hydrogen/components/product-variant
 [hydrogen-use-query]: https://shopify.dev/api/hydrogen/hooks/global/usequery
-[storefront-api]: https://shopify.dev/api/usage/authentication#access-tokens-for-the-storefront-api
+[shopify-headless-app]: https://apps.shopify.com/headless
 [license]: https://github.com/sanity-io/sanity/blob/next/LICENSE
 [sanity-connect]: https://www.sanity.io/docs/sanity-connect-for-shopify
 [sanity-js-client]: https://www.sanity.io/docs/js-client


### PR DESCRIPTION
Shopify released a new easier way to manage Storefront API tokens. Updated instructions to match.