### PR TITLE
Fix product intents

### DIFF
--- a/packages/sanity/src/desk/products.ts
+++ b/packages/sanity/src/desk/products.ts
@@ -51,11 +51,15 @@ export default defineStructure<ListItemBuilder>((S) =>
         .child(async (id) =>
           S.list()
             .title('Product')
+            .canHandleIntent(
+              (intentName, params) => intentName === 'edit' && params.type === 'product'
+            )
             .items([
-              // Details
               S.listItem()
                 .title('Details')
                 .icon(InfoOutlineIcon)
+                .schemaType('product')
+                .id(id)
                 .child(
                   S.document()
                     .schemaType('product')
@@ -79,6 +83,10 @@ export default defineStructure<ListItemBuilder>((S) =>
                     .params({
                       productId: Number(id.replace('shopifyProduct-', '')),
                     })
+                    .canHandleIntent(
+                      (intentName, params) =>
+                        intentName === 'edit' && params.type === 'productVariant'
+                    )
                 ),
             ])
         )


### PR DESCRIPTION
Add `canHandleIntent` for products and variants, and fixes listItem missing `schemaType` and `id`. Solves issue with document restore action not working.