### PR TITLE
fix: hotspot previews

### DIFF
--- a/apps/storefront/app/components/media/ImageWithProductHotspots.tsx
+++ b/apps/storefront/app/components/media/ImageWithProductHotspots.tsx
@@ -1,10 +1,8 @@
 import { useMatches } from "@remix-run/react";
-import type { Product } from "@shopify/hydrogen/storefront-api-types";
 
 import SanityImage from "~/components/media/SanityImage";
 import ProductHotspot from "~/components/product/Hotspot";
 import type { SanityImageWithProductHotspots } from "~/lib/sanity";
-import { useGids } from "~/lib/utils";
 
 type Props = {
   content: SanityImageWithProductHotspots;
@@ -13,17 +11,18 @@ type Props = {
 export default function ImageWithProductHotspots({ content }: Props) {
   const [root] = useMatches();
   const { sanityDataset, sanityProjectID } = root.data;
-  const gids = useGids();
 
   return (
     <>
       {content.productHotspots?.map((hotspot) => {
-        const storefrontProduct = gids.get(hotspot?.product?.gid) as Product;
+        if (!hotspot?.product?.gid) {
+          return null;
+        }
 
         return (
           <ProductHotspot
             key={hotspot._key}
-            storefrontProduct={storefrontProduct}
+            productGid={hotspot?.product?.gid}
             variantGid={hotspot?.product?.variantGid}
             x={hotspot.x}
             y={hotspot.y}

--- a/apps/storefront/app/components/modules/Image.tsx
+++ b/apps/storefront/app/components/modules/Image.tsx
@@ -1,5 +1,4 @@
 import { useMatches } from "@remix-run/react";
-import type { Product } from "@shopify/hydrogen/storefront-api-types";
 import clsx from "clsx";
 
 import Button from "~/components/elements/Button";
@@ -8,15 +7,12 @@ import SanityImage from "~/components/media/SanityImage";
 import ProductHotspot from "~/components/product/Hotspot";
 import ProductTag from "~/components/product/Tag";
 import type { SanityModuleImage } from "~/lib/sanity";
-import { useGids } from "~/lib/utils";
 
 type Props = {
   module: SanityModuleImage;
 };
 
 export default function ImageModule({ module }: Props) {
-  const gids = useGids();
-
   if (!module.image) {
     return null;
   }
@@ -61,12 +57,14 @@ export default function ImageModule({ module }: Props) {
       {module.variant === "productTags" && (
         <div className="mt-2 flex flex-wrap gap-x-1 gap-y-2">
           {module.productTags?.map((tag) => {
-            const storefrontProduct = gids.get(tag?.gid) as Product;
+            if (!tag?.gid) {
+              return null;
+            }
 
             return (
               <ProductTag
                 key={tag._key}
-                storefrontProduct={storefrontProduct}
+                productGid={tag?.gid}
                 variantGid={tag?.variantGid}
               />
             );

--- a/apps/storefront/app/components/modules/Image.tsx
+++ b/apps/storefront/app/components/modules/Image.tsx
@@ -41,14 +41,14 @@ export default function ImageModule({ module }: Props) {
       {module.variant === "productHotspots" && (
         <>
           {module.productHotspots?.map((hotspot) => {
-            const storefrontProduct = gids.get(
-              hotspot?.product?.gid
-            ) as Product;
+            if (!hotspot?.product?.gid) {
+              return null;
+            }
 
             return (
               <ProductHotspot
                 key={hotspot._key}
-                storefrontProduct={storefrontProduct}
+                productGid={hotspot?.product?.gid}
                 variantGid={hotspot?.product?.variantGid}
                 x={hotspot.x}
                 y={hotspot.y}

--- a/apps/storefront/app/components/product/Hotspot.tsx
+++ b/apps/storefront/app/components/product/Hotspot.tsx
@@ -1,23 +1,26 @@
+import type { Product } from "@shopify/hydrogen/storefront-api-types";
 import Tippy from "@tippyjs/react/headless";
 import clsx from "clsx";
 
 import { Link } from "~/components/Link";
 import ProductTile from "~/components/product/Tile";
-import { ProductWithNodes } from "~/types/shopify";
+import { useGid } from "~/lib/utils";
 
 type Props = {
-  storefrontProduct: ProductWithNodes;
+  productGid: string;
   variantGid?: string;
   x: number;
   y: number;
 };
 
 export default function ProductHotspot({
-  storefrontProduct,
+  productGid,
   variantGid,
   x,
   y,
 }: Props) {
+  const storefrontProduct = useGid<Product>(productGid);
+
   if (!storefrontProduct) {
     return null;
   }

--- a/apps/storefront/app/components/product/Tag.tsx
+++ b/apps/storefront/app/components/product/Tag.tsx
@@ -1,17 +1,22 @@
-import type { ProductVariant } from "@shopify/hydrogen/storefront-api-types";
+import type {
+  Product,
+  ProductVariant,
+} from "@shopify/hydrogen/storefront-api-types";
 import Tippy from "@tippyjs/react/headless";
 import clsx from "clsx";
 
 import { Link } from "~/components/Link";
 import ProductTooltip from "~/components/product/Tooltip";
-import type { ProductWithNodes } from "~/types/shopify";
+import { useGid } from "~/lib/utils";
 
 type Props = {
-  storefrontProduct: ProductWithNodes;
+  productGid: Product["id"];
   variantGid?: ProductVariant["id"];
 };
 
-export default function ProductTag({ storefrontProduct, variantGid }: Props) {
+export default function ProductTag({ productGid, variantGid }: Props) {
+  const storefrontProduct = useGid<Product>(productGid);
+
   if (!storefrontProduct) {
     return null;
   }

--- a/apps/storefront/app/routes/_store.tsx
+++ b/apps/storefront/app/routes/_store.tsx
@@ -58,11 +58,7 @@ export default function Store() {
   const { preview } = useLoaderData<typeof loader>();
 
   return (
-    <PreviewProvider
-      previewConfig={{ ...preview, resultSourceMap: true }}
-      fallback={<PreviewLoading />}
-      turboSourceMap={true}
-    >
+    <PreviewProvider previewConfig={preview} fallback={<PreviewLoading />}>
       <Layout>
         <Outlet />
       </Layout>


### PR DESCRIPTION
- Changes hotspots to use `useGid` rather than `useGids` to ensure new hotspots are rendered in preview mode.
- Removes `resultSourceMap` and `turboSourceMap` as some queries as unsupported in content source maps, which leads to a slower / janky preview performance.